### PR TITLE
Add media support to quick_reply, fix device auth user switching

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "socials",
       "source": "./",
       "description": "Connect Claude to X, LinkedIn, and Reddit via the Socials browser extension. Post, engage, search, and manage social media directly from Claude Code.",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "author": {
         "name": "Brainrot Creations"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "socials",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Connect Claude to X, LinkedIn, and Reddit via the Socials browser extension. Post, engage, search, and manage social media directly from Claude Code.",
   "author": {
     "name": "Brainrot Creations"

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -26100,8 +26100,8 @@ var ExtensionBridge = class {
   async getPageContent(tabId) {
     return this.sendRequest("get_page_content", { tabId });
   }
-  async quickReply(postId, content) {
-    return this.sendRequest("quick_reply", { postId, content });
+  async quickReply(postId, content, media) {
+    return this.sendRequest("quick_reply", { postId, content, media });
   }
   async createPost(payload) {
     return this.sendRequest("create_post", payload);
@@ -26400,7 +26400,7 @@ var allTools = [
   // },
   {
     name: "socials_quick_reply",
-    description: "Reply from the pinned agent tab's feed (see socials_open_tab)\u2014that tab need not be focused. Clicks reply on the tweet, types the content, and posts. You can write the reply yourself OR use socials_generate_reply first if you want to use the user's persona. IMPORTANT: Always confirm with the user before posting.",
+    description: "Reply from the pinned agent tab's feed (see socials_open_tab)\u2014that tab need not be focused. Clicks reply on the tweet, types the content, optionally attaches media (images, GIFs, videos), and posts. You can write the reply yourself OR use socials_generate_reply first if you want to use the user's persona. IMPORTANT: Always confirm with the user before posting.",
     inputSchema: {
       type: "object",
       properties: {
@@ -26411,6 +26411,25 @@ var allTools = [
         content: {
           type: "string",
           description: "The reply content (you can write this yourself)"
+        },
+        media: {
+          type: "array",
+          description: "Optional media to attach. Accepts local file paths (e.g., /path/to/image.png) or URLs. Max 4 images or 1 video/GIF.",
+          items: {
+            type: "object",
+            properties: {
+              path: {
+                type: "string",
+                description: "Local file path or URL to the media file"
+              },
+              type: {
+                type: "string",
+                enum: ["image", "video", "gif"],
+                description: "Type of media"
+              }
+            },
+            required: ["path", "type"]
+          }
         }
       },
       required: ["post_id", "content"]
@@ -27038,7 +27057,46 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         await requireProAccess();
         const postId = args.post_id;
         const content = args.content;
-        const result = await bridge.quickReply(postId, content);
+        const rawMedia = args.media;
+        const processedMedia = rawMedia ? await Promise.all(
+          rawMedia.map(async (item) => {
+            let normalizedPath = item.path;
+            if (normalizedPath.startsWith("file://")) {
+              normalizedPath = normalizedPath.slice(7);
+            }
+            const isUrl = normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
+            if (isUrl) {
+              return { url: normalizedPath, type: item.type };
+            } else {
+              const filePath = normalizedPath.startsWith("~") ? normalizedPath.replace("~", process.env.HOME || "") : normalizedPath;
+              if (!fs.existsSync(filePath)) {
+                throw new Error(`Media file not found: ${filePath}`);
+              }
+              const fileBuffer = fs.readFileSync(filePath);
+              const base64Data = fileBuffer.toString("base64");
+              const filename = path.basename(filePath);
+              const ext = path.extname(filePath).toLowerCase().slice(1);
+              const mimeTypes = {
+                jpg: "image/jpeg",
+                jpeg: "image/jpeg",
+                png: "image/png",
+                gif: "image/gif",
+                webp: "image/webp",
+                mp4: "video/mp4",
+                mov: "video/quicktime",
+                webm: "video/webm"
+              };
+              const mimeType = mimeTypes[ext] || "application/octet-stream";
+              return {
+                data: base64Data,
+                filename,
+                mimeType,
+                type: item.type
+              };
+            }
+          })
+        ) : void 0;
+        const result = await bridge.quickReply(postId, content, processedMedia);
         const elapsed = getElapsed();
         trackReplySent("x", content, result.success, elapsed);
         await trackToolUsage(name, "x", result.success, elapsed);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-plugins",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Official Socials Claude Code plugin: MCP server for the Socials browser extension (Claude Desktop compatible)",
   "type": "module",
   "main": "dist/index.js",

--- a/src/extension-bridge.ts
+++ b/src/extension-bridge.ts
@@ -451,8 +451,18 @@ export class ExtensionBridge {
     }>("get_page_content", { tabId });
   }
 
-  async quickReply(postId: string, content: string): Promise<{ success: boolean; error?: string }> {
-    return this.sendRequest<{ success: boolean; error?: string }>("quick_reply", { postId, content });
+  async quickReply(
+    postId: string,
+    content: string,
+    media?: Array<{
+      url?: string;
+      data?: string;
+      filename?: string;
+      mimeType?: string;
+      type: "image" | "video" | "gif";
+    }>
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.sendRequest<{ success: boolean; error?: string }>("quick_reply", { postId, content, media });
   }
 
   async createPost(payload: CreatePostPayload): Promise<{ success: boolean; error?: string }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,7 +298,7 @@ const allTools = [
         name: "socials_quick_reply",
         description:
           "Reply from the pinned agent tab's feed (see socials_open_tab)—that tab need not be focused. " +
-          "Clicks reply on the tweet, types the content, and posts. " +
+          "Clicks reply on the tweet, types the content, optionally attaches media (images, GIFs, videos), and posts. " +
           "You can write the reply yourself OR use socials_generate_reply first if you want to use the user's persona. " +
           "IMPORTANT: Always confirm with the user before posting.",
         inputSchema: {
@@ -311,6 +311,25 @@ const allTools = [
             content: {
               type: "string",
               description: "The reply content (you can write this yourself)",
+            },
+            media: {
+              type: "array",
+              description: "Optional media to attach. Accepts local file paths (e.g., /path/to/image.png) or URLs. Max 4 images or 1 video/GIF.",
+              items: {
+                type: "object",
+                properties: {
+                  path: {
+                    type: "string",
+                    description: "Local file path or URL to the media file",
+                  },
+                  type: {
+                    type: "string",
+                    enum: ["image", "video", "gif"],
+                    description: "Type of media",
+                  },
+                },
+                required: ["path", "type"],
+              },
             },
           },
           required: ["post_id", "content"],
@@ -1049,8 +1068,61 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         await requireProAccess();
         const postId = (args as { post_id: string }).post_id;
         const content = (args as { content: string }).content;
+        const rawMedia = (args as { media?: Array<{ path: string; type: "image" | "video" | "gif" }> }).media;
 
-        const result = await bridge.quickReply(postId, content);
+        // Process media: convert local files to base64, keep URLs as-is (same as create_post)
+        const processedMedia = rawMedia
+          ? await Promise.all(
+              rawMedia.map(async (item) => {
+                // Normalize the path - strip file:// protocol if present
+                let normalizedPath = item.path;
+                if (normalizedPath.startsWith("file://")) {
+                  normalizedPath = normalizedPath.slice(7);
+                }
+
+                const isUrl = normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
+
+                if (isUrl) {
+                  return { url: normalizedPath, type: item.type };
+                } else {
+                  // Local file - read and convert to base64
+                  const filePath = normalizedPath.startsWith("~")
+                    ? normalizedPath.replace("~", process.env.HOME || "")
+                    : normalizedPath;
+
+                  if (!fs.existsSync(filePath)) {
+                    throw new Error(`Media file not found: ${filePath}`);
+                  }
+
+                  const fileBuffer = fs.readFileSync(filePath);
+                  const base64Data = fileBuffer.toString("base64");
+                  const filename = path.basename(filePath);
+                  const ext = path.extname(filePath).toLowerCase().slice(1);
+
+                  const mimeTypes: Record<string, string> = {
+                    jpg: "image/jpeg",
+                    jpeg: "image/jpeg",
+                    png: "image/png",
+                    gif: "image/gif",
+                    webp: "image/webp",
+                    mp4: "video/mp4",
+                    mov: "video/quicktime",
+                    webm: "video/webm",
+                  };
+                  const mimeType = mimeTypes[ext] || "application/octet-stream";
+
+                  return {
+                    data: base64Data,
+                    filename,
+                    mimeType,
+                    type: item.type,
+                  };
+                }
+              })
+            )
+          : undefined;
+
+        const result = await bridge.quickReply(postId, content, processedMedia);
 
         // Track reply sent with content analysis and timing
         const elapsed = getElapsed();


### PR DESCRIPTION
## Summary
- `socials_quick_reply` now accepts media parameter (images, GIFs, videos) - same as `socials_create_post`
- Fixed device registration to always update to current cookie user on `check_access`
- Simplified `refresh_auth` flow
- Fixed RLS SELECT policy to allow UPSERT for user switching

## Test plan
- [x] Test quick_reply with media attachment
- [x] Test device auth after switching users on website
- [x] Verify check_access registers device to current user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the reply-posting path to accept and process local files/URLs (base64 encoding, MIME detection), which could cause posting failures or unexpected file handling errors if paths or media types are incorrect.
> 
> **Overview**
> `socials_quick_reply` now supports **optional media attachments** (images/GIFs/videos), including schema updates and end-to-end wiring through `src/index.ts` and `ExtensionBridge.quickReply`, with local files converted to base64 and URLs passed through.
> 
> Versions are bumped to `1.0.35` and the bundled `dist/index.cjs` output is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd5e8dcef9b5be66700986a149d5ebdbe0a8ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->