### PR TITLE
dev

### DIFF
--- a/plugins/socials/.claude-plugin/plugin.json
+++ b/plugins/socials/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "socials",
-  "description": "Connect Claude to X, LinkedIn, and Reddit via the Socials browser extension. Post, engage, search, and manage social media directly from Claude Code.",
+  "description": "Connect Claude to X, LinkedIn, Reddit, and YouTube (browser open, navigate, scroll) via the Socials browser extension. Post, engage, search, and manage social media directly from Claude Code.",
   "author": {
     "name": "Brainrot Creations",
     "email": "support@brainrotcreations.com"

--- a/plugins/socials/.mcp.json
+++ b/plugins/socials/.mcp.json
@@ -1,10 +1,11 @@
 {
   "mcpServers": {
     "socials": {
-      "command": "npx",
-      "args": ["-y", "@brainrotcreations/socials"],
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/run-claude-mcp.sh"],
       "env": {
-        "SOCIALS_MCP_RECLAIM_PORT": "1"
+        "SOCIALS_MCP_RECLAIM_PORT": "1",
+        "SOCIALS_MCP_DEV_MODE": "1"
       }
     }
   }

--- a/plugins/socials/.mcp.json
+++ b/plugins/socials/.mcp.json
@@ -5,7 +5,7 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/run-claude-mcp.sh"],
       "env": {
         "SOCIALS_MCP_RECLAIM_PORT": "1",
-        "SOCIALS_MCP_DEV_MODE": "1"
+        "SOCIALS_MCP_DEV_MODE": "0"
       }
     }
   }

--- a/plugins/socials/commands/setup/SKILL.md
+++ b/plugins/socials/commands/setup/SKILL.md
@@ -25,9 +25,10 @@ Then offer quick start options:
 Say something like:
 "Let's get you set up with Socials! This will take about 2 minutes.
 
-Socials connects Claude to your social media accounts (X, LinkedIn, Reddit) through a browser extension. You'll be able to:
+Socials connects Claude to your social media accounts (X, LinkedIn, Reddit) through a browser extension, and can **open YouTube** in the browser for you (home, a video, or search results). You'll be able to:
 - Post and reply directly from here
 - Search and browse feeds
+- Open YouTube with **`socials_open_tab`** (e.g. `https://www.youtube.com/` or search: `https://www.youtube.com/results?search_query=...` with URL-encoded terms)
 - Engage with your audience
 - All without leaving Claude Code
 
@@ -77,7 +78,7 @@ Here's what you can do now:
 - `/search` - Search for content
 - `/feed` - Browse your timeline
 
-Or just tell me what you'd like to do - 'help me post about X' or 'find AI discussions on LinkedIn'
+Or just tell me what you'd like to do - 'help me post about X', 'find AI discussions on LinkedIn', or 'open YouTube and search for hello kitty'
 
 What would you like to try first?"
 

--- a/plugins/socials/commands/using-socials/SKILL.md
+++ b/plugins/socials/commands/using-socials/SKILL.md
@@ -24,7 +24,7 @@ Follow this flow unless the user explicitly asks for something else.
 
 ## 3. Read content
 
-- **`socials_fetch_image`** — pass a direct **image URL** (e.g. `thumbnailUrl` from YouTube cards, X `pbs.twimg.com`, Reddit preview URLs). Returns an **MCP image** for side-by-side visual inspection without opening tabs. Requires the same **Socials Pro + extension** connection as other MCP tools. Public CDN URLs work; cookie-only private URLs may fail (fetch runs in the MCP process).
+- **`socials_fetch_image`** — pass a direct **image URL** (e.g. `thumbnailUrl` from YouTube cards, X `pbs.twimg.com`, Reddit preview URLs). Returns an **MCP image** for side-by-side visual inspection without opening tabs. **Token policy:** image blocks are high-cost; use this only when it materially improves the outcome (visual comparison/detail checks). If text/URLs are enough, keep thumbnails as URLs and summarize from metadata. Requires the same **Socials Pro + extension** connection as other MCP tools. Public CDN URLs work; cookie-only private URLs may fail (fetch runs in the MCP process).
 - **`socials_get_feed`** — recent posts from a feed (requires **Socials Pro**; extension should be on the right feed page).
 - **`socials_get_post_context`** — thread/reply context for a **post URL** (Pro).
 - **`socials_get_page_content`** — on **YouTube search results** (`/results?search_query=…`), returns **video cards** (title, URL, **thumbnail URL**, channel, views, duration, snippet). The extension **auto-scrolls** the results list between scrapes (infinite scroll) until **`limit`** is reached or no new rows load. Optional **`limit`** (1–80, default 40). On X/LinkedIn/Reddit, feed snippets as before.

--- a/plugins/socials/commands/using-socials/SKILL.md
+++ b/plugins/socials/commands/using-socials/SKILL.md
@@ -24,9 +24,10 @@ Follow this flow unless the user explicitly asks for something else.
 
 ## 3. Read content
 
+- **`socials_fetch_image`** — pass a direct **image URL** (e.g. `thumbnailUrl` from YouTube cards, X `pbs.twimg.com`, Reddit preview URLs). Returns an **MCP image** for side-by-side visual inspection without opening tabs. Requires the same **Socials Pro + extension** connection as other MCP tools. Public CDN URLs work; cookie-only private URLs may fail (fetch runs in the MCP process).
 - **`socials_get_feed`** — recent posts from a feed (requires **Socials Pro**; extension should be on the right feed page).
 - **`socials_get_post_context`** — thread/reply context for a **post URL** (Pro).
-- **`socials_get_page_content`** — content from the **current** page after you have opened the right tab (on YouTube you may get little structured data without a dedicated adapter).
+- **`socials_get_page_content`** — on **YouTube search results** (`/results?search_query=…`), returns **video cards** (title, URL, **thumbnail URL**, channel, views, duration, snippet). The extension **auto-scrolls** the results list between scrapes (infinite scroll) until **`limit`** is reached or no new rows load. Optional **`limit`** (1–80, default 40). On X/LinkedIn/Reddit, feed snippets as before.
 
 ## 4. Drafting and posting
 

--- a/plugins/socials/commands/using-socials/SKILL.md
+++ b/plugins/socials/commands/using-socials/SKILL.md
@@ -20,14 +20,17 @@ Follow this flow unless the user explicitly asks for something else.
 - **If platform is X:** use **`socials_x_search`** first, then **`socials_get_feed`** / **`socials_quick_reply`** / (optionally) **`socials_engage_post`** on results.
 - **If platform is LinkedIn:** use **`socials_open_tab`** with `https://www.linkedin.com/feed/` and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts and replies. Use **`socials_linkedin_posts_search`** to search for posts, then **`socials_get_feed`** to read results. Use **`socials_linkedin_engage_post`** to like or repost.
 - **If platform is Reddit:** use **`socials_open_tab`** with the subreddit URL and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts.
-- **If the user wants YouTube:** use **`socials_open_tab`** with `https://www.youtube.com/` (home), a watch URL, or **search results** `https://www.youtube.com/results?search_query=...` where the query value is **URL-encoded** (same idea as `encodeURIComponent`). Refine search with **`socials_navigate`** on the agent tab. Feed/reply tools (**`socials_get_feed`**, **`socials_quick_reply`**, etc.) are for X/LinkedIn/Reddit only—not for parsing YouTube result lists unless a future adapter exists.
+- **If the user wants YouTube:** use **`socials_open_tab`** with `https://www.youtube.com/` (home), a watch URL, or **search results** `https://www.youtube.com/results?search_query=...` where the query value is **URL-encoded** (same idea as `encodeURIComponent`). Refine search with **`socials_navigate`** on the agent tab. To apply filters (Type/Duration/Upload date/Features/Prioritize), use the standard tool **`socials_apply_search_filters`** with `platform: "youtube"` and filter labels. Feed/reply tools (**`socials_get_feed`**, **`socials_quick_reply`**, etc.) are for X/LinkedIn/Reddit only—not for parsing YouTube result lists unless a future adapter exists.
 
 ## 3. Read content
 
 - **`socials_fetch_image`** — pass a direct **image URL** (e.g. `thumbnailUrl` from YouTube cards, X `pbs.twimg.com`, Reddit preview URLs). Returns an **MCP image** for side-by-side visual inspection without opening tabs. **Token policy:** image blocks are high-cost; use this only when it materially improves the outcome (visual comparison/detail checks). If text/URLs are enough, keep thumbnails as URLs and summarize from metadata. Requires the same **Socials Pro + extension** connection as other MCP tools. Public CDN URLs work; cookie-only private URLs may fail (fetch runs in the MCP process).
 - **`socials_get_feed`** — recent posts from a feed (requires **Socials Pro**; extension should be on the right feed page).
 - **`socials_get_post_context`** — thread/reply context for a **post URL** (Pro).
-- **`socials_get_page_content`** — on **YouTube search results** (`/results?search_query=…`), returns **video cards** (title, URL, **thumbnail URL**, channel, views, duration, snippet). The extension **auto-scrolls** the results list between scrapes (infinite scroll) until **`limit`** is reached or no new rows load. Optional **`limit`** (1–80, default 40). On X/LinkedIn/Reddit, feed snippets as before.
+- **`socials_get_page_content`** —
+  - On **YouTube search results** (`/results?search_query=…`): returns **video cards** (title, URL, **thumbnail URL**, channel, views, duration, snippet) with auto-scroll until **`limit`** is reached or no new rows load.
+  - On **YouTube watch pages** (`/watch?v=…`): returns structured `page_data` with title/channel/views/likes/description/comments count and extracted comments. Use `comment_sort: "top" | "newest"` to switch ordering before scrape, `comments_limit` (1–120, default 20), and `expand_description` (default true).
+  - On X/LinkedIn/Reddit: feed snippets as before.
 
 ## 4. Drafting and posting
 

--- a/plugins/socials/commands/using-socials/SKILL.md
+++ b/plugins/socials/commands/using-socials/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-socials
-description: Use when the user wants to read feeds, inspect posts, draft or post replies, list personas, or control the browser for X, LinkedIn, or Reddit via the Socials extension. Apply whenever Socials MCP tools are relevant to the task.
+description: Use when the user wants to read feeds, inspect posts, draft or post replies, list personas, or control the browser for X, LinkedIn, Reddit, or YouTube via the Socials extension. Apply whenever Socials MCP tools are relevant to the task.
 ---
 
 # Working with Socials (MCP tools)
@@ -15,17 +15,18 @@ Follow this flow unless the user explicitly asks for something else.
 ## 2. Open the right context in the browser
 
 - Use **`socials_open_tab`** with a concrete URL first. That tab is **pinned** as the Socials **agent tab**: feed, reply, scroll, search, and engage run there even if the user is focused on another tab or another **Chrome window**—automation uses the pinned tab id, not “the focused window.” By default the tab opens in the **background**; use **`focus: true`** to switch to it, or **`socials_focus_agent_tab`** to bring that tab’s window forward. Additional **`socials_open_tab`** calls open in the **same window as the pinned tab** when possible so a new empty window does not hijack the agent workspace.
-- **`socials_get_agent_tab`** — see which tab is pinned. **`socials_set_agent_tab`** — pin an existing tab (e.g. X already open) by `tab_id` from **`socials_get_active_tab`**.
+- **`socials_get_agent_tab`** — see which tab is pinned (`platform` may be `x`, `linkedin`, `reddit`, or `youtube`). **`socials_set_agent_tab`** — pin an existing tab (e.g. X or YouTube already open) by `tab_id` from **`socials_get_active_tab`**.
 - Use **`socials_navigate`**, **`socials_reload_tab`**, or **`socials_scroll`** on the agent tab (omit `tab_id` unless targeting a specific tab). **`socials_get_active_tab`** is the **focused** tab (what the user sees), not necessarily the agent tab.
 - **If platform is X:** use **`socials_x_search`** first, then **`socials_get_feed`** / **`socials_quick_reply`** / (optionally) **`socials_engage_post`** on results.
 - **If platform is LinkedIn:** use **`socials_open_tab`** with `https://www.linkedin.com/feed/` and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts and replies. Use **`socials_linkedin_posts_search`** to search for posts, then **`socials_get_feed`** to read results. Use **`socials_linkedin_engage_post`** to like or repost.
 - **If platform is Reddit:** use **`socials_open_tab`** with the subreddit URL and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts.
+- **If the user wants YouTube:** use **`socials_open_tab`** with `https://www.youtube.com/` (home), a watch URL, or **search results** `https://www.youtube.com/results?search_query=...` where the query value is **URL-encoded** (same idea as `encodeURIComponent`). Refine search with **`socials_navigate`** on the agent tab. Feed/reply tools (**`socials_get_feed`**, **`socials_quick_reply`**, etc.) are for X/LinkedIn/Reddit only—not for parsing YouTube result lists unless a future adapter exists.
 
 ## 3. Read content
 
 - **`socials_get_feed`** — recent posts from a feed (requires **Socials Pro**; extension should be on the right feed page).
 - **`socials_get_post_context`** — thread/reply context for a **post URL** (Pro).
-- **`socials_get_page_content`** — content from the **current** page after you have opened the right tab.
+- **`socials_get_page_content`** — content from the **current** page after you have opened the right tab (on YouTube you may get little structured data without a dedicated adapter).
 
 ## 4. Drafting and posting
 

--- a/plugins/socials/commands/using-socials/SKILL.md
+++ b/plugins/socials/commands/using-socials/SKILL.md
@@ -20,7 +20,7 @@ Follow this flow unless the user explicitly asks for something else.
 - **If platform is X:** use **`socials_x_search`** first, then **`socials_get_feed`** / **`socials_quick_reply`** / (optionally) **`socials_engage_post`** on results.
 - **If platform is LinkedIn:** use **`socials_open_tab`** with `https://www.linkedin.com/feed/` and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts and replies. Use **`socials_linkedin_posts_search`** to search for posts, then **`socials_get_feed`** to read results. Use **`socials_linkedin_engage_post`** to like or repost.
 - **If platform is Reddit:** use **`socials_open_tab`** with the subreddit URL and then **`socials_get_feed`** / **`socials_quick_reply`** (optionally **`socials_scroll`**) to work with posts.
-- **If the user wants YouTube:** use **`socials_open_tab`** with `https://www.youtube.com/` (home), a watch URL, or **search results** `https://www.youtube.com/results?search_query=...` where the query value is **URL-encoded** (same idea as `encodeURIComponent`). Refine search with **`socials_navigate`** on the agent tab. To apply filters (Type/Duration/Upload date/Features/Prioritize), use the standard tool **`socials_apply_search_filters`** with `platform: "youtube"` and filter labels. Feed/reply tools (**`socials_get_feed`**, **`socials_quick_reply`**, etc.) are for X/LinkedIn/Reddit only—not for parsing YouTube result lists unless a future adapter exists.
+- **If the user wants YouTube:** use **`socials_open_tab`** with `https://www.youtube.com/` (home), a watch URL, or **search results** `https://www.youtube.com/results?search_query=...` where the query value is **URL-encoded** (same idea as `encodeURIComponent`). Refine search with **`socials_navigate`** on the agent tab. To apply filters (Type/Duration/Upload date/Features/Prioritize), use **`socials_apply_search_filters`** with `platform: "youtube"` and filter labels. Read search cards with **`socials_get_page_content`**; on **watch** pages use **`socials_get_page_content`** for metadata + comments (each has **`commentId`** — the YouTube `lc` token). To **reply to a YouTube comment**, use **`socials_quick_reply`** with `post_id` set to that **`commentId`**. **`socials_get_feed`** is not used for YouTube.
 
 ## 3. Read content
 
@@ -36,7 +36,7 @@ Follow this flow unless the user explicitly asks for something else.
 
 - **`socials_list_personas`** — when the user cares about tone or persona-backed generation.
 - **`socials_generate_reply`** — optional AI-assisted draft from Socials (Pro); you may also write copy yourself.
-- **`socials_quick_reply`** — posts a reply **in the browser** from the feed. **Always confirm exact text with the user before calling** — this is a real post.
+- **`socials_quick_reply`** — posts a reply **in the browser**: X/LinkedIn from the feed (post id from **`socials_get_feed`**); **YouTube watch** — `post_id` = **`commentId`** from **`socials_get_page_content`** `page_data.comments`. **Always confirm exact text with the user before calling** — this is a real post.
 
 ## 5. Errors and limits
 

--- a/plugins/socials/scripts/run-claude-mcp.sh
+++ b/plugins/socials/scripts/run-claude-mcp.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
-# Launcher for stdio MCP when not using the Claude Code plugin loader (e.g. manual MCP config).
-# Plugin installs use .mcp.json with ${CLAUDE_PLUGIN_ROOT}/dist/index.js (Socials Claude Code plugin).
+# Launcher for Socials MCP.
+# - Default: published package via `npx -y @brainrotcreations/socials`
+# - Dev mode: local build at socials/mcp/dist/index.cjs
 set -euo pipefail
-ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
-exec node "$ROOT/dist/index.js"
+
+ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DEV_MODE="${SOCIALS_MCP_DEV_MODE:-0}"
+
+if [[ "$DEV_MODE" == "1" || "$DEV_MODE" == "true" || "$DEV_MODE" == "TRUE" ]]; then
+  LOCAL_ENTRY_DEFAULT="$ROOT/../../../socials/mcp/dist/index.cjs"
+  LOCAL_ENTRY="${SOCIALS_MCP_DEV_MCP_PATH:-$LOCAL_ENTRY_DEFAULT}"
+
+  if [[ ! -f "$LOCAL_ENTRY" ]]; then
+    echo "[socials] Dev mode enabled but local MCP entry not found: $LOCAL_ENTRY" >&2
+    echo "[socials] Build it first: cd \"$ROOT/../../../socials/mcp\" && npm run build" >&2
+    exit 1
+  fi
+
+  exec node "$LOCAL_ENTRY"
+fi
+
+exec npx -y @brainrotcreations/socials

--- a/plugins/socials/skills/feed/SKILL.md
+++ b/plugins/socials/skills/feed/SKILL.md
@@ -15,7 +15,7 @@ Get the latest posts from your social media feed.
    ```
 
 2. **Determine platform**
-   Ask if not provided: X, LinkedIn, or Reddit?
+   Ask if not provided: X, LinkedIn, or Reddit? (YouTube is not supported by **`socials_get_feed`**—use **`socials_open_tab`** with `https://www.youtube.com/` or a channel/subscriptions URL, and **`socials_scroll`** if needed; see **`using-socials`**.)
 
 3. **Open the feed**
 

--- a/plugins/socials/skills/search/SKILL.md
+++ b/plugins/socials/skills/search/SKILL.md
@@ -64,6 +64,7 @@ Search for posts, topics, and conversations across platforms.
    socials_get_feed({ platform: "[platform]" })
    ```
    For YouTube, call **`socials_get_page_content`** (optional **`limit`**, 1–80, default 40) to read **video cards** from the results page.
+   Call **`socials_fetch_image`** for thumbnail URLs only when visual inspection materially improves the answer (comparison/detail checks). If text/URLs are enough, keep image URLs as text to reduce token usage.
 
 6. **Offer next actions**
    - Get more details on a specific post

--- a/plugins/socials/skills/search/SKILL.md
+++ b/plugins/socials/skills/search/SKILL.md
@@ -63,7 +63,7 @@ Search for posts, topics, and conversations across platforms.
    ```
    socials_get_feed({ platform: "[platform]" })
    ```
-   For YouTube, the user views results in the browser tab; **`socials_get_page_content`** may return limited structured data without a YouTube adapter.
+   For YouTube, call **`socials_get_page_content`** (optional **`limit`**, 1–80, default 40) to read **video cards** from the results page.
 
 6. **Offer next actions**
    - Get more details on a specific post

--- a/plugins/socials/skills/search/SKILL.md
+++ b/plugins/socials/skills/search/SKILL.md
@@ -56,14 +56,22 @@ Search for posts, topics, and conversations across platforms.
      url: "https://www.youtube.com/results?search_query=hello+kitty"
    })
    ```
-   Use **`socials_navigate`** on the agent tab to change the search. Structured feed extraction is not available for YouTube the way it is for X/LinkedIn/Reddit.
+   Use **`socials_navigate`** on the agent tab to change the search. Apply search filters with:
+   ```
+   socials_apply_search_filters({
+     platform: "youtube",
+     filters: ["Videos", "This week", "HD"]
+   })
+   ```
+  For a specific video page (`/watch?v=...`), use `socials_get_page_content` to extract video metadata plus comments.
 
 5. **Show results**
    For X, LinkedIn, or Reddit:
    ```
    socials_get_feed({ platform: "[platform]" })
    ```
-   For YouTube, call **`socials_get_page_content`** (optional **`limit`**, 1–80, default 40) to read **video cards** from the results page.
+  For YouTube search results, call **`socials_get_page_content`** (optional **`limit`**, 1–80, default 40) to read **video cards** from the results page.
+  For YouTube watch pages, call **`socials_get_page_content`** with optional `comment_sort` (`top` or `newest`) and `comments_limit` to read fresh comments in that order.
    Call **`socials_fetch_image`** for thumbnail URLs only when visual inspection materially improves the answer (comparison/detail checks). If text/URLs are enough, keep image URLs as text to reduce token usage.
 
 6. **Offer next actions**

--- a/plugins/socials/skills/search/SKILL.md
+++ b/plugins/socials/skills/search/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Search for posts and content on X, LinkedIn, or Reddit
+description: Search for posts and content on X, LinkedIn, or Reddit; open YouTube search results via browser URL
 user-invocable: true
 ---
 
@@ -15,7 +15,7 @@ Search for posts, topics, and conversations across platforms.
    ```
 
 2. **Get search parameters**
-   - Platform: X, LinkedIn, or Reddit?
+   - Platform: X, LinkedIn, Reddit, or YouTube?
    - Keywords or search query
    - Type: Latest, Top, or People (X only)
 
@@ -49,10 +49,21 @@ Search for posts, topics, and conversations across platforms.
    socials_get_feed({ platform: "reddit" })
    ```
 
+   **On YouTube (search in the browser):**
+   There is no separate MCP search tool. Build a results URL and open it (URL-encode the query, same idea as `encodeURIComponent`):
+   ```
+   socials_open_tab({
+     url: "https://www.youtube.com/results?search_query=hello+kitty"
+   })
+   ```
+   Use **`socials_navigate`** on the agent tab to change the search. Structured feed extraction is not available for YouTube the way it is for X/LinkedIn/Reddit.
+
 5. **Show results**
+   For X, LinkedIn, or Reddit:
    ```
    socials_get_feed({ platform: "[platform]" })
    ```
+   For YouTube, the user views results in the browser tab; **`socials_get_page_content`** may return limited structured data without a YouTube adapter.
 
 6. **Offer next actions**
    - Get more details on a specific post


### PR DESCRIPTION
- **Youtube Additions**
- **feat(socials): add dev mode MCP launcher and YouTube search card support**
- **docs(socials): add token policy guidance for socials_fetch_image usage**
- **docs(socials): add YouTube filter and watch-page comment support to skills**
- **docs(socials): add YouTube comment reply guidance to SKILL.md**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MCP server launch path/config (switches `.mcp.json` to a bash launcher with optional local dev entry), which could affect plugin startup and developer environments; the rest is documentation-only guidance for new YouTube flows.
> 
> **Overview**
> **Adds YouTube support guidance across Socials skills/docs**: setup, `using-socials`, `feed`, and `search` now describe opening YouTube via `socials_open_tab`, scraping search/watch pages via `socials_get_page_content`, applying filters with `socials_apply_search_filters`, and replying to comments using YouTube `commentId`.
> 
> **Updates MCP launch configuration for development**: `.mcp.json` now runs a new `scripts/run-claude-mcp.sh` launcher (instead of direct `npx`), with a `SOCIALS_MCP_DEV_MODE` path that can run a local built MCP entry or fall back to the published package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4c7f4f8cd133fc7adf7f998816a2e4f443fa6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->